### PR TITLE
Fixes table-caption/table layout issue in Firefox

### DIFF
--- a/tufte.css
+++ b/tufte.css
@@ -45,6 +45,7 @@ p.subtitle { font-style: italic;
              line-height: 1; }
 
 table { width: 98%;
+        clear: left;
         text-align: right;
         font-size: 1.2rem;
         line-height: 1.4;


### PR DESCRIPTION
Chrome, Safari, Opera (e.g., below, left) are OK, but at mobil-ish widths, Firefox 40.0.3/Mac (below, right) fumbles the table-caption layout:

![scrap-tuftecss-tables-sqz](https://cloud.githubusercontent.com/assets/1248937/9588014/b493cc7a-4ff3-11e5-8d47-4f9c6c8784f8.jpg)

Inserting an explicit `clear: left` in the CSS for `table` seems to fix it, causing tables to be positioned below table-captions, instead of colliding with them in Firefox.
